### PR TITLE
Disable elements in InlineLexer as well

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -766,11 +766,7 @@ InlineLexer.prototype.mangle = function(text) {
  */
 
 function Renderer(options) {
-	this.options = options || {};
-
-	for(var i = 0; i < this.options.disabledElements.length; i++) {
-    	this[this.options.disabledElements[i]] = noop;
-  	}
+  this.options = options || {};
 }
 
 Renderer.prototype.code = function(code, lang, escaped) {

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -542,6 +542,10 @@ function InlineLexer(links, options) {
   } else if (this.options.pedantic) {
     this.rules = inline.pedantic;
   }
+
+  for(var i = 0; i < this.options.disabledElements.length; i++) {
+    this.rules[this.options.disabledElements[i]] = noop;
+  }
 }
 
 /**

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -766,7 +766,11 @@ InlineLexer.prototype.mangle = function(text) {
  */
 
 function Renderer(options) {
-  this.options = options || {};
+	this.options = options || {};
+
+	for(var i = 0; i < this.options.disabledElements.length; i++) {
+    	this[this.options.disabledElements[i]] = noop;
+  	}
 }
 
 Renderer.prototype.code = function(code, lang, escaped) {


### PR DESCRIPTION
Previously only Lexer checked the disabledElements option, now InlineLexer does as well.